### PR TITLE
User Home Page/Feed first implementation

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -14,7 +14,7 @@ const SignIn = () => {
     const email = target.email.value;
     const password = target.password.value;
     const result = await signIn('credentials', {
-      callbackUrl: '/',
+      callbackUrl: '/feed',
       email,
       password,
     });

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,0 +1,24 @@
+// app/feed/page.tsx
+import React from 'react';
+import { getServerSession } from 'next-auth';
+import authOptions from '@/lib/authOptions';
+import { loggedInProtectedPage } from '@/lib/page-protection';
+import FeedList from '@/components/FeedList';
+
+const FeedPage = async () => {
+  // Protect the page, only logged-in users can access it.
+  const session = await getServerSession(authOptions);
+  loggedInProtectedPage(
+    session as {
+      user: { email: string; id: string; randomKey: string };
+    } | null,
+  );
+
+  return (
+    <main>
+      <FeedList />
+    </main>
+  );
+};
+
+export default FeedPage;

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Container, Row, Col, Card, Badge } from 'react-bootstrap';
+
+interface Jam {
+  id: number;
+  organizer: string;
+  genre: string;
+  location: string;
+  date: Date;
+  instruments: string;
+  experience: 'novice' | 'beginner' | 'intermediate' | 'professional';
+  description: string;
+}
+
+const FeedList: React.FC = () => {
+  const [jams, setJams] = useState<Jam[]>([]);
+
+  // Mock data
+  useEffect(() => {
+    const mockJams: Jam[] = [
+      {
+        id: 1,
+        organizer: 'user1@example.com',
+        genre: 'Reggae',
+        location: 'Honolulu Community Center',
+        date: new Date('2024-11-20T18:00:00'),
+        instruments: 'Guitar, Bass, Drums',
+        experience: 'intermediate',
+        description: 'Practicing some classic Reggae tunes.',
+      },
+      {
+        id: 2,
+        organizer: 'user2@example.com',
+        genre: 'Punk Rock',
+        location: 'Warehouse',
+        date: new Date('2024-11-25T20:00:00'),
+        instruments: 'Vocals, Guitar',
+        experience: 'beginner',
+        description: 'Looking for any musicians to try out some punk rock 2000s focused music.',
+      },
+      {
+        id: 3,
+        organizer: 'user3@example.com',
+        genre: 'Electronic',
+        location: 'Republik',
+        date: new Date('2024-12-01T19:00:00'),
+        instruments: 'Ableton/CDJs',
+        experience: 'intermediate',
+        description: 'Need a DJ for this date. Experience with house and EDM djing required.',
+      },
+    ];
+
+    // Sort jams by date (soonest first)
+    const sortedJams = mockJams.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    setJams(sortedJams);
+  }, []);
+
+  return (
+    <Container className="mt-4">
+      <h2 className="mb-4">Upcoming Jams</h2>
+      <Row>
+        {jams.map((jam) => (
+          <Col xs={12} md={6} lg={4} key={jam.id} className="mb-4">
+            <Card>
+              <Card.Body>
+                <Card.Title>
+                  {jam.genre}
+                  {' '}
+                  Jam
+                </Card.Title>
+                <Card.Subtitle className="mb-2 text-muted">
+                  Organized by
+                  {' '}
+                  {jam.organizer}
+                </Card.Subtitle>
+                <Card.Text>
+                  <strong>Location:</strong>
+                  {' '}
+                  {jam.location}
+                  <br />
+                  <strong>Instruments:</strong>
+                  {' '}
+                  {jam.instruments}
+                  <br />
+                  <strong>Experience Level:</strong>
+                  {' '}
+                  <Badge bg="info" text="dark">
+                    {jam.experience.charAt(0).toUpperCase() + jam.experience.slice(1)}
+                  </Badge>
+                  <br />
+                  {jam.description}
+                </Card.Text>
+              </Card.Body>
+              <Card.Footer>
+                <small className="text-muted">
+                  Jam Date:
+                  {' '}
+                  {jam.date.toLocaleDateString()}
+                  {' '}
+                  at
+                  {' '}
+                  {jam.date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </small>
+              </Card.Footer>
+            </Card>
+          </Col>
+        ))}
+      </Row>
+    </Container>
+  );
+};
+
+export default FeedList;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable react/jsx-indent, @typescript-eslint/indent */
+/* Josh : View Edit Profile has no link, will link to the User Profile Page (to be implemented later?) */
 
 'use client';
 
 import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
-import { Container, Nav, Navbar, NavDropdown, Image } from 'react-bootstrap';
-import { BoxArrowRight, Lock, PersonFill, PersonPlusFill } from 'react-bootstrap-icons';
+import { Container, Nav, Navbar, NavDropdown, Image, NavLink } from 'react-bootstrap';
+import { BoxArrowRight, Lock, Person, PersonFill, PersonPlusFill } from 'react-bootstrap-icons';
 
 const NavBar: React.FC = () => {
   const { data: session } = useSession();
@@ -26,21 +27,26 @@ const NavBar: React.FC = () => {
         <Navbar.Toggle aria-controls="basic-navbar-nav" />
         <Navbar.Collapse id="basic-navbar-nav">
           <Nav className="me-auto justify-content-start">
-            {currentUser
-              ? [
-                  <Nav.Link
-                    id="create-jam-nav"
-                    href="/jam-information"
-                    key="create-jam"
-                    active={pathName === '/jam-information'}
-                  >
-                    Create a Jam
-                  </Nav.Link>,
-                  <Nav.Link id="list-stuff-nav" href="/list" key="list" active={pathName === '/list'}>
-                    List Stuff
-                  </Nav.Link>,
-                ]
-              : ''}
+          {currentUser
+            ? [
+                <Nav.Link
+                  id="feed-nav"
+                  href="/feed"
+                  key="feed"
+                  active={pathName === '/feed'}
+                >
+                  Feed
+                </Nav.Link>,
+                <Nav.Link
+                  id="create-jam-nav"
+                  href="/jam-information"
+                  key="create-jam"
+                  active={pathName === '/jam-information'}
+                >
+                  Create a Jam
+                </Nav.Link>,
+              ]
+            : ''}
             {currentUser && role === 'ADMIN' ? (
               <Nav.Link id="admin-stuff-nav" href="/admin" key="admin" active={pathName === '/admin'}>
                 Admin
@@ -52,6 +58,10 @@ const NavBar: React.FC = () => {
           <Nav>
             {session ? (
               <NavDropdown id="login-dropdown" title={currentUser}>
+                <NavDropdown.Item id="login-dropdown-view-profile" href="/profile">
+                 <Person />
+                  View/Edit Profile
+                </NavDropdown.Item>
                 <NavDropdown.Item id="login-dropdown-sign-out" href="/api/auth/signout">
                   <BoxArrowRight />
                   Sign Out


### PR DESCRIPTION
Decided to change user home page to 'feed' page. This lists the events/jams, sorts by date, closest upcoming date first. Will most likely reformat to horizontal cards? Navbar now has a 'feed' button. Signing in as user will now redirect to the feed.